### PR TITLE
ci: add @claude mention workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,54 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Only run when someone actually mentions @claude, in any of the four places.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Lets Claude read CI results on PRs it is asked about.
+          additional_permissions: |
+            actions: read
+
+          # No prompt: Claude follows whatever the comment that tagged it asked for.
+
+          # v1 passes model and tool grants through the CLI rather than inputs.
+          # The action's own default model (claude-sonnet-4) is retired, so pin it.
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash(bun run test),Bash(bun run lint),Bash(bun run typecheck)"


### PR DESCRIPTION
- adds `.github/workflows/claude.yml` so `@claude` in issues, PR comments and reviews triggers a run
- salvaged from `add-claude-github-actions-1786527656660`, taking only this file; that branch's `claude-code-review.yml` changes are its stale fork point and would revert checkout@v7, bun setup, the opus-5 pin and the review opt-outs
- brought in line with the sibling workflows: checkout@v7, `oven-sh/setup-bun@v2`, `--model claude-opus-5` (the action's default model is retired, so an unpinned run fails)