### PR TITLE
docs: make the documented contract match the action

### DIFF
--- a/API.md
+++ b/API.md
@@ -604,22 +604,22 @@ All outputs are provided as strings (GitHub Actions requirement) and available f
 
 ---
 
-### `urls` (Deploy Only)
+### `outputs` (Deploy Only)
 
-**Description:** Deployed application URLs extracted from generic outputs  
-**Type:** String (JSON Array)  
-**Format:** JSON-encoded array of URLs  
+**Description:** Generic outputs declared by the SST application
+**Type:** String (JSON Array)
+**Format:** JSON-encoded array of `{ "key": ..., "value": ... }` objects
 
 **Example Values:**
 ```json
-["https://api.example.com"]
-["https://web.example.com", "https://api.example.com"]
+[{"key":"Api","value":"https://api.example.com"}]
+[{"key":"Web","value":"https://web.example.com"},{"key":"Api","value":"https://api.example.com"}]
 []
 ```
 
 **Usage:**
 ```yaml
-- name: Extract URLs
+- name: Deploy
   id: deploy
   uses: kodehort/sst-operations-action@v1
   with:
@@ -627,40 +627,51 @@ All outputs are provided as strings (GitHub Actions requirement) and available f
     stage: production
     token: ${{ secrets.GITHUB_TOKEN }}
 
-- name: Process URLs
+- name: Use deployment outputs
   run: |
-    URLS='${{ steps.deploy.outputs.urls }}'
-    echo "Raw URLs: $URLS"
-    
-    # Parse JSON array
-    echo "First URL: $(echo '$URLS' | jq -r '.[0] // "none"')"
-    
-    # Set as environment variables
-    API_URL=$(echo '$URLS' | jq -r '.[] | select(contains("api"))')
-    WEB_URL=$(echo '$URLS' | jq -r '.[] | select(contains("web"))')
-    
-    echo "API_URL=$API_URL" >> $GITHUB_ENV
-    echo "WEB_URL=$WEB_URL" >> $GITHUB_ENV
+    OUTPUTS='${{ steps.deploy.outputs.outputs }}'
 
-- name: Test Deployed URLs
-  run: |
-    for url in $(echo '${{ steps.deploy.outputs.urls }}' | jq -r '.[]'); do
-      echo "Testing: $url"
+    # Look one up by name
+    API_URL=$(echo "$OUTPUTS" | jq -r '.[] | select(.key == "Api") | .value')
+    echo "API_URL=$API_URL" >> $GITHUB_ENV
+
+    # Or iterate every URL-shaped value
+    for url in $(echo "$OUTPUTS" | jq -r '.[].value | select(startswith("http"))'); do
       curl -f "$url/health" || echo "Health check failed for $url"
     done
 ```
 
-**URL Types:**
-- API endpoints (API Gateway, ALB)
-- Web applications (CloudFront, S3)
-- Function URLs (Lambda)
-- WebSocket APIs
+**Notes:**
+- Only populated for `deploy` operations; empty string for `diff`, `remove` and `stage`
+- Empty array `[]` if the deployment declared no outputs
+- Whatever the SST app declares, not only URLs — parse by `key` rather than assuming position
+
+---
+
+### `resources` (Deploy Only)
+
+**Description:** The resources SST reported during the deployment
+**Type:** String (JSON Array)
+**Format:** JSON-encoded array of `{ "name": ..., "type": ..., "status": ... }` objects
+
+**Example Values:**
+```json
+[{"name":"MyFunction","type":"Function","status":"created"}]
+[]
+```
+
+**Usage:**
+```yaml
+- name: Report created resources
+  run: |
+    echo '${{ steps.deploy.outputs.resources }}' \
+      | jq -r '.[] | select(.status == "created") | "\(.type) \(.name)"'
+```
 
 **Notes:**
-- Only populated for `deploy` operations
-- Empty array `[]` if no URLs found in outputs
-- JSON parsing required to extract individual URLs
-- URLs are extracted from the generic SST outputs during parsing
+- Only populated for `deploy` operations; empty string for `diff`, `remove` and `stage`
+- `resource_changes` is the count of this array's entries
+- `status` is normalised by the parser (e.g. `created`, `updated`, `deleted`, `failed`)
 
 ---
 
@@ -696,6 +707,77 @@ All outputs are provided as strings (GitHub Actions requirement) and available f
 - Only populated for `diff` operations
 - Empty string if no changes or parsing failed
 - Human-readable format for notifications and reports
+
+---
+
+### `planned_changes` (Diff Only)
+
+**Description:** Number of changes SST plans to make
+**Type:** String (Integer)
+**Format:** Numeric string
+
+**Example Values:**
+```
+"0"
+"27"
+```
+
+**Usage:**
+```yaml
+- name: Gate on planned changes
+  run: |
+    if [ "${{ steps.diff.outputs.planned_changes }}" != "0" ]; then
+      echo "Infrastructure changes are pending review"
+    fi
+```
+
+**Notes:**
+- Only populated for `diff` operations; empty string for `deploy`, `remove` and `stage`
+- `resource_changes` carries the same value for `diff`, so either can be read
+
+---
+
+### `resources_removed` (Remove Only)
+
+**Description:** Number of resources removed
+**Type:** String (Integer)
+**Format:** Numeric string
+
+**Usage:**
+```yaml
+- name: Report cleanup
+  run: echo "Removed ${{ steps.cleanup.outputs.resources_removed }} resources"
+```
+
+**Notes:**
+- Only populated for `remove` operations; empty string for `deploy`, `diff` and `stage`
+- `resource_changes` carries the same value for `remove`
+
+---
+
+### `removed_resources` (Remove Only)
+
+**Description:** The resources SST removed
+**Type:** String (JSON Array)
+**Format:** JSON-encoded array of `{ "name": ..., "type": ..., "status": ... }` objects
+
+**Example Values:**
+```json
+[{"name":"MyFunction","type":"Function","status":"removed"}]
+[]
+```
+
+**Usage:**
+```yaml
+- name: List removed resources
+  run: |
+    echo '${{ steps.cleanup.outputs.removed_resources }}' \
+      | jq -r '.[] | "\(.type) \(.name)"'
+```
+
+**Notes:**
+- Only populated for `remove` operations; empty string for `deploy`, `diff` and `stage`
+- Note the name: `resources_removed` is the count, `removed_resources` is the list
 
 ---
 
@@ -955,6 +1037,28 @@ All outputs are provided as strings (GitHub Actions requirement) and available f
 
 ---
 
+### `error`
+
+**Description:** Error message when the operation fails
+**Type:** String
+**Format:** Plain text; empty on success
+
+**Usage:**
+```yaml
+- name: Report failure
+  if: failure()
+  run: |
+    echo "SST ${{ steps.sst.outputs.operation }} failed:"
+    echo "${{ steps.sst.outputs.error }}"
+```
+
+**Notes:**
+- Populated for every operation, including `stage`
+- Empty string when the operation succeeded, so test for emptiness rather than presence
+- Set independently of `fail-on-error`: with `fail-on-error: false` the workflow continues and this output is the way to detect the failure
+
+---
+
 ## Operations
 
 Detailed behavior for each operation type.
@@ -979,7 +1083,8 @@ Detailed behavior for each operation type.
 
 **Outputs Populated:**
 - All standard outputs
-- `urls` - Array of URLs extracted from generic outputs
+- `outputs` - JSON array of the app's declared outputs, as `{key, value}` pairs
+- `resources` - JSON array of the resources SST reported
 - `resource_changes` - Number of resources modified
 
 **Example:**
@@ -995,8 +1100,8 @@ Detailed behavior for each operation type.
     
 - name: Test Deployed Application
   run: |
-    URLS='${{ steps.deploy.outputs.urls }}'
-    for url in $(echo "$URLS" | jq -r '.[]'); do
+    URLS=$(echo '${{ steps.deploy.outputs.outputs }}' | jq -r '.[].value | select(type == "string" and startswith("http"))')
+    for url in $URLS; do
       curl -f "$url/health" || exit 1
     done
 ```
@@ -1236,12 +1341,12 @@ Detailed behavior for each operation type.
   run: |
     if [ "${{ steps.deploy.outputs.success }}" = "true" ]; then
       echo "✅ Deployment successful"
-      echo "URLs deployed: ${{ steps.deploy.outputs.urls }}"
+      echo "Outputs: ${{ steps.deploy.outputs.outputs }}"
       echo "Resources changed: ${{ steps.deploy.outputs.resource_changes }}"
       
       # Run health checks
-      URLS='${{ steps.deploy.outputs.urls }}'
-      for url in $(echo "$URLS" | jq -r '.[]'); do
+      URLS=$(echo '${{ steps.deploy.outputs.outputs }}' | jq -r '.[].value | select(type == "string" and startswith("http"))')
+      for url in $URLS; do
         echo "Testing: $url"
         curl -f "$url/health" || exit 1
       done
@@ -1401,7 +1506,9 @@ stage: "staging"
 app: "my-app"
 completion_status: "failed"
 resource_changes: "0"
-urls: "[]"
+outputs: "[]"
+resources: "[]"
+error: "Deployment failed: <reason>"
 truncated: "false"
 permalink: ""
 ```

--- a/README.md
+++ b/README.md
@@ -62,9 +62,14 @@ Unified GitHub Action for SST operations: deploy, diff, remove, and stage comput
 | `operation` | Operation performed | All |
 | `stage` | Stage operated on | All |
 | `app` | SST app name | deploy, diff, remove |
-| `resource_changes` | Number of resource changes | deploy, remove |
-| `outputs` | JSON array of deployment outputs (key/value pairs) | deploy |
+| `resource_changes` | Number of resource changes; mirrors `planned_changes` for diff and `resources_removed` for remove | deploy, diff, remove |
+| `outputs` | JSON array of deployment outputs (`key`/`value` pairs) | deploy |
+| `resources` | JSON array of reported resources (`name`/`type`/`status`) | deploy |
 | `diff_summary` | Summary of planned changes | diff |
+| `planned_changes` | Number of changes SST plans to make | diff |
+| `resources_removed` | Number of resources removed | remove |
+| `removed_resources` | JSON array of removed resources (`name`/`type`/`status`) | remove |
+| `error` | Error message when the operation fails; empty on success | All |
 | `completion_status` | `complete`, `partial`, or `failed` | All |
 | `permalink` | SST Console permalink | deploy, diff, remove |
 | `truncated` | Whether output was truncated | All |

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -394,7 +394,7 @@ Warning: Resource changes could not be determined
   run: |
     echo "Success: '${{ steps.deploy.outputs.success }}'"
     echo "Operation: '${{ steps.deploy.outputs.operation }}'"
-    echo "URLs: '${{ steps.deploy.outputs.urls }}'"
+    echo "Outputs: '${{ steps.deploy.outputs.outputs }}'"
     echo "Resource Changes: '${{ steps.deploy.outputs.resource_changes }}'"
 ```
 
@@ -589,7 +589,7 @@ Error: Resource with identifier [xyz] already exists
     echo "App: '${{ steps.deploy.outputs.app }}'"
     echo "Completion Status: '${{ steps.deploy.outputs.completion_status }}'"
     echo "Resource Changes: '${{ steps.deploy.outputs.resource_changes }}'"
-    echo "URLs: '${{ steps.deploy.outputs.urls }}'"
+    echo "Outputs: '${{ steps.deploy.outputs.outputs }}'"
     echo "Permalink: '${{ steps.deploy.outputs.permalink }}'"
     echo "Truncated: '${{ steps.deploy.outputs.truncated }}'"
 

--- a/__tests__/outputs/action-metadata.test.ts
+++ b/__tests__/outputs/action-metadata.test.ts
@@ -1,0 +1,286 @@
+/**
+ * The action's declared output contract has to match what it emits.
+ *
+ * `main.ts` iterates the formatter's keys blindly into `core.setOutput`, so an
+ * output that nobody declared still works — it is simply invisible to anyone
+ * reading `action.yml`. Five had drifted out of the metadata that way, and
+ * `src/outputs/schema.ts` claimed to "match the outputs defined in action.yml
+ * exactly" while it did not.
+ *
+ * The emitted set here is produced by running the formatter, not read from a
+ * hand-maintained list, so a new key reaches this test the moment it can reach
+ * a consumer.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { OutputFormatter } from "../../src/outputs/formatter";
+import type {
+  DeployResult,
+  DiffResult,
+  OperationResult,
+  RemoveResult,
+  StageResult,
+} from "../../src/types";
+
+/**
+ * Read the keys of the `outputs:` block from action.yml.
+ *
+ * Parsed rather than pulled in with a YAML library: the block is a flat
+ * key/description map in a file this repository owns, and a dev dependency
+ * added for one test is a dependency the bundle gate then has to reason about.
+ */
+function declaredOutputs(): string[] {
+  const lines = readFileSync(join(process.cwd(), "action.yml"), "utf8").split(
+    "\n"
+  );
+
+  const start = lines.indexOf("outputs:");
+  if (start === -1) {
+    throw new Error("action.yml has no outputs: block");
+  }
+
+  const keys: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    // A non-indented, non-empty line ends the block.
+    if (/^\S/.test(line)) {
+      break;
+    }
+    const match = line.match(/^ {2}([a-z_]+):\s*$/);
+    if (match) {
+      keys.push(match[1] as string);
+    }
+  }
+
+  return keys;
+}
+
+/** Alphabetical, so mismatches read as a diff rather than a reordering. */
+function sorted(keys: string[]): string[] {
+  return [...keys].sort((a, b) => a.localeCompare(b));
+}
+
+/** The output names in the README's `## Outputs` table. */
+function readmeOutputTable(): string[] {
+  const content = readFileSync(join(process.cwd(), "README.md"), "utf8");
+  const heading = "## Outputs\n";
+  const section = content
+    .slice(content.indexOf(heading) + heading.length)
+    .split(/^## /m)[0] as string;
+
+  return [...section.matchAll(/^\| `([a-z_]+)` \|/gm)].map(
+    (match) => match[1] as string
+  );
+}
+
+/** The output names given a `### \`name\`` section under API.md's `## Outputs`. */
+function apiReferenceSections(): string[] {
+  const content = readFileSync(join(process.cwd(), "API.md"), "utf8");
+  const heading = "\n## Outputs\n";
+  const section = content
+    .slice(content.indexOf(heading) + heading.length)
+    .split(/^## /m)[0] as string;
+
+  return [...section.matchAll(/^### `([a-z_]+)`/gm)].map(
+    (match) => match[1] as string
+  );
+}
+
+const deploy: DeployResult = {
+  app: "test-app",
+  completionStatus: "complete",
+  exitCode: 0,
+  operation: "deploy",
+  outputs: [{ key: "API", value: "https://api.example.com" }],
+  permalink: "https://console.sst.dev/test-app/staging/deployments/abc123",
+  rawOutput: "",
+  resourceChanges: 1,
+  resources: [{ name: "MyFunction", status: "created", type: "Function" }],
+  stage: "staging",
+  success: true,
+  truncated: false,
+};
+
+const diff: DiffResult = {
+  app: "test-app",
+  changeSummary: "1 change planned",
+  changes: [],
+  completionStatus: "complete",
+  exitCode: 0,
+  operation: "diff",
+  plannedChanges: 1,
+  rawOutput: "",
+  stage: "staging",
+  success: true,
+  truncated: false,
+};
+
+const remove: RemoveResult = {
+  app: "test-app",
+  completionStatus: "complete",
+  exitCode: 0,
+  operation: "remove",
+  rawOutput: "",
+  removedResources: [
+    { name: "MyFunction", status: "removed", type: "Function" },
+  ],
+  resourcesRemoved: 1,
+  stage: "staging",
+  success: true,
+  truncated: false,
+};
+
+const stage: StageResult = {
+  app: "",
+  completionStatus: "complete",
+  computedStage: "pr-123",
+  eventName: "pull_request",
+  exitCode: 0,
+  isPullRequest: true,
+  operation: "stage",
+  rawOutput: "",
+  ref: "refs/pull/123/merge",
+  stage: "pr-123",
+  success: true,
+  truncated: false,
+};
+
+/** Every key any operation can put in front of a consumer. */
+function emittedOutputs(): string[] {
+  const results: OperationResult[] = [deploy, diff, remove, stage];
+  const keys = new Set<string>();
+
+  for (const result of results) {
+    for (const key of Object.keys(
+      OutputFormatter.formatOperationForGitHubActions(result)
+    )) {
+      keys.add(key);
+    }
+  }
+
+  return sorted([...keys]);
+}
+
+describe("Declared action outputs", () => {
+  it("declares every output the formatter emits", () => {
+    const declared = declaredOutputs();
+    const emitted = emittedOutputs();
+
+    // Guards against a parse that silently returns nothing, which would make
+    // the comparison below pass for the wrong reason.
+    expect(declared.length).toBeGreaterThan(0);
+
+    expect(
+      emitted.filter((key) => !declared.includes(key)),
+      "Emitted by the formatter but absent from action.yml"
+    ).toEqual([]);
+  });
+
+  it("declares nothing the formatter never emits", () => {
+    const emitted = emittedOutputs();
+
+    expect(
+      declaredOutputs().filter((key) => !emitted.includes(key)),
+      "Declared in action.yml but never emitted"
+    ).toEqual([]);
+  });
+
+  it("keeps the documented field list in step with what is emitted", () => {
+    // getExpectedFields() is hand-maintained and used as the contract by other
+    // tests, so it drifts the same way action.yml did.
+    expect(sorted(OutputFormatter.getExpectedFields())).toEqual(
+      emittedOutputs()
+    );
+  });
+
+  it("lists every output in the README table", () => {
+    const rows = readmeOutputTable();
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(sorted(rows), "README Outputs table vs action.yml").toEqual(
+      sorted(declaredOutputs())
+    );
+  });
+
+  it("documents every output in the API reference", () => {
+    const sections = apiReferenceSections();
+
+    expect(sections.length).toBeGreaterThan(0);
+    expect(sorted(sections), "API.md Outputs sections vs action.yml").toEqual(
+      sorted(declaredOutputs())
+    );
+  });
+});
+
+/**
+ * Example workflows are the copy-paste surface, so a reference to an output the
+ * action does not emit silently expands to an empty string. `urls` sat in these
+ * files long after it was replaced by `outputs`.
+ *
+ * Only steps that use this action are checked — the examples also read outputs
+ * from their own `run` steps, which are none of this test's business.
+ */
+const EXAMPLE_WORKFLOWS = [
+  "examples/basic-deploy.yml",
+  "examples/cleanup.yml",
+  "examples/error-handling.yml",
+  "examples/multi-environment.yml",
+  "examples/pr-workflow.yml",
+];
+
+interface ExampleReference {
+  file: string;
+  key: string;
+  stepId: string;
+}
+
+function actionStepReferences(): ExampleReference[] {
+  const references: ExampleReference[] = [];
+
+  for (const file of EXAMPLE_WORKFLOWS) {
+    const content = readFileSync(join(process.cwd(), file), "utf8");
+
+    // Split on list items, so each chunk is one step.
+    const steps = content.split(/^\s*- (?=name:|uses:|id:)/m);
+    const actionStepIds = new Set<string>();
+
+    for (const step of steps) {
+      if (!step.includes("uses: kodehort/sst-ops-action@")) {
+        continue;
+      }
+      const id = step.match(/^\s*id:\s*(\S+)\s*$/m);
+      if (id) {
+        actionStepIds.add(id[1] as string);
+      }
+    }
+
+    for (const match of content.matchAll(
+      /steps\.([\w-]+)\.outputs\.([\w-]+)/g
+    )) {
+      const stepId = match[1] as string;
+      if (actionStepIds.has(stepId)) {
+        references.push({ file, key: match[2] as string, stepId });
+      }
+    }
+  }
+
+  return references;
+}
+
+describe("Example workflows", () => {
+  it("only read outputs the action declares", () => {
+    const references = actionStepReferences();
+    const declared = declaredOutputs();
+
+    // Without this, a step-block split that matched nothing would look clean.
+    expect(references.length).toBeGreaterThan(10);
+
+    expect(
+      references
+        .filter((r) => !declared.includes(r.key))
+        .map((r) => `${r.file}: steps.${r.stepId}.outputs.${r.key}`),
+      "Example workflows read an output the action never emits"
+    ).toEqual([]);
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -99,9 +99,16 @@ outputs:
   stage:
     description: "The stage that was operated on"
   resource_changes:
-    description: "Number of resource changes made (deploy/remove only)"
+    description: |
+      Number of resource changes, as a numeric string:
+      • deploy: resources created, updated or deleted
+      • diff: same value as planned_changes
+      • remove: same value as resources_removed
+      • stage: empty
+  resources:
+    description: "JSON array of the resources SST reported, each with name, type and status (deploy only; empty for other operations)"
   outputs:
-    description: "JSON array of generic outputs from deployment (replaces urls)"
+    description: "JSON array of generic outputs from the deployment, each with key and value (deploy only; empty for other operations)"
   app:
     description: "The SST app name"
   completion_status:
@@ -112,6 +119,14 @@ outputs:
     description: "Whether the operation output was truncated"
   diff_summary:
     description: "Summary of planned changes (diff only)"
+  planned_changes:
+    description: "Number of changes SST plans to make, as a numeric string (diff only; empty for other operations)"
+  resources_removed:
+    description: "Number of resources removed, as a numeric string (remove only; empty for other operations)"
+  removed_resources:
+    description: "JSON array of the resources SST removed, each with name, type and status (remove only; empty for other operations)"
+  error:
+    description: "Error message when the operation fails; empty on success (all operations)"
   computed_stage:
     description: "The computed stage name (stage only)"
   ref:

--- a/examples/basic-deploy.yml
+++ b/examples/basic-deploy.yml
@@ -114,11 +114,14 @@ jobs:
           if [ "${{ steps.deploy.outputs.success }}" = "true" ]; then
             echo "- **Resources Changed**: ${{ steps.deploy.outputs.resource_changes }}" >> $GITHUB_STEP_SUMMARY
             
-            # Display deployed URLs if available
-            URLS='${{ steps.deploy.outputs.urls }}'
-            if [ "$URLS" != "[]" ] && [ -n "$URLS" ]; then
+            # Display deployed URLs if available. The action emits every
+            # output the app declared, as {key, value} pairs, so pick out the
+            # URL-shaped ones.
+            URLS=$(echo '${{ steps.deploy.outputs.outputs }}' \
+              | jq -r '.[].value | select(type == "string" and startswith("http"))')
+            if [ -n "$URLS" ]; then
               echo "- **Deployed URLs**:" >> $GITHUB_STEP_SUMMARY
-              echo "$URLS" | jq -r '.[] | "  - " + .' >> $GITHUB_STEP_SUMMARY
+              echo "$URLS" | sed 's/^/  - /' >> $GITHUB_STEP_SUMMARY
             fi
             
             # Include console permalink if available
@@ -132,12 +135,13 @@ jobs:
       # Optional: Run basic health checks on deployed URLs
       # This demonstrates post-deployment validation
       - name: Health Check
-        if: steps.deploy.outputs.success == 'true' && steps.deploy.outputs.urls != '[]'
+        if: steps.deploy.outputs.success == 'true' && steps.deploy.outputs.outputs != '[]'
         run: |
           echo "Running health checks on deployed URLs..."
-          URLS='${{ steps.deploy.outputs.urls }}'
-          
-          for url in $(echo "$URLS" | jq -r '.[]'); do
+          URLS=$(echo '${{ steps.deploy.outputs.outputs }}' \
+            | jq -r '.[].value | select(type == "string" and startswith("http"))')
+
+          for url in $URLS; do
             echo "Checking: $url"
             
             # Simple HTTP health check

--- a/examples/error-handling.yml
+++ b/examples/error-handling.yml
@@ -176,6 +176,9 @@ jobs:
     name: Deploy with Error Handling
     runs-on: ubuntu-latest
     needs: pre-deployment-validation
+    
+    outputs:
+      deployment_outputs: ${{ steps.final-status.outputs.deployment_outputs }}
     if: |
       needs.pre-deployment-validation.outputs.validation_passed == 'true' ||
       github.event.inputs.force_deployment == 'true'
@@ -318,25 +321,25 @@ jobs:
             echo "final_success=true" >> $GITHUB_OUTPUT
             echo "final_attempt=primary" >> $GITHUB_OUTPUT
             echo "resource_changes=${{ steps.deploy-primary.outputs.resource_changes }}" >> $GITHUB_OUTPUT
-            echo "urls=${{ steps.deploy-primary.outputs.urls }}" >> $GITHUB_OUTPUT
+            echo "deployment_outputs=${{ steps.deploy-primary.outputs.outputs }}" >> $GITHUB_OUTPUT
             echo "permalink=${{ steps.deploy-primary.outputs.permalink }}" >> $GITHUB_OUTPUT
           elif [ "${{ steps.deploy-retry.outputs.success }}" = "true" ]; then
             echo "final_success=true" >> $GITHUB_OUTPUT
             echo "final_attempt=retry" >> $GITHUB_OUTPUT
             echo "resource_changes=${{ steps.deploy-retry.outputs.resource_changes }}" >> $GITHUB_OUTPUT
-            echo "urls=${{ steps.deploy-retry.outputs.urls }}" >> $GITHUB_OUTPUT
+            echo "deployment_outputs=${{ steps.deploy-retry.outputs.outputs }}" >> $GITHUB_OUTPUT
             echo "permalink=${{ steps.deploy-retry.outputs.permalink }}" >> $GITHUB_OUTPUT
           elif [ "${{ steps.deploy-final.outputs.success }}" = "true" ]; then
             echo "final_success=true" >> $GITHUB_OUTPUT
             echo "final_attempt=final" >> $GITHUB_OUTPUT
             echo "resource_changes=${{ steps.deploy-final.outputs.resource_changes }}" >> $GITHUB_OUTPUT
-            echo "urls=${{ steps.deploy-final.outputs.urls }}" >> $GITHUB_OUTPUT
+            echo "deployment_outputs=${{ steps.deploy-final.outputs.outputs }}" >> $GITHUB_OUTPUT
             echo "permalink=${{ steps.deploy-final.outputs.permalink }}" >> $GITHUB_OUTPUT
           else
             echo "final_success=false" >> $GITHUB_OUTPUT
             echo "final_attempt=all_failed" >> $GITHUB_OUTPUT
             echo "resource_changes=0" >> $GITHUB_OUTPUT
-            echo "urls=[]" >> $GITHUB_OUTPUT
+            echo "deployment_outputs=[]" >> $GITHUB_OUTPUT
             echo "permalink=" >> $GITHUB_OUTPUT
           fi
 
@@ -373,10 +376,11 @@ jobs:
             echo "### Deployment Results" >> $GITHUB_STEP_SUMMARY
             echo "- **Resources Changed**: ${{ steps.final-status.outputs.resource_changes }}" >> $GITHUB_STEP_SUMMARY
             
-            URLS='${{ steps.final-status.outputs.urls }}'
-            if [ "$URLS" != "[]" ] && [ -n "$URLS" ]; then
+            URLS=$(echo '${{ steps.final-status.outputs.deployment_outputs }}' \
+              | jq -r '.[].value | select(type == "string" and startswith("http"))')
+            if [ -n "$URLS" ]; then
               echo "- **Deployed URLs**:" >> $GITHUB_STEP_SUMMARY
-              echo "$URLS" | jq -r '.[] | "  - " + .' >> $GITHUB_STEP_SUMMARY
+              echo "$URLS" | sed 's/^/  - /' >> $GITHUB_STEP_SUMMARY
             fi
             
             if [ -n "${{ steps.final-status.outputs.permalink }}" ]; then
@@ -393,7 +397,8 @@ jobs:
             const success = '${{ steps.final-status.outputs.final_success }}' === 'true';
             const attempt = '${{ steps.final-status.outputs.final_attempt }}';
             const stage = '${{ steps.params.outputs.stage }}';
-            const urls = JSON.parse('${{ steps.final-status.outputs.urls }}' || '[]');
+            const deployed = JSON.parse('${{ steps.final-status.outputs.deployment_outputs }}' || '[]');
+            const urls = deployed.filter(o => String(o.value).startsWith('http'));
             
             let comment = `## ${success ? '🚀' : '❌'} Deployment ${success ? 'Successful' : 'Failed'}\n\n`;
             comment += `**Stage**: ${stage}\n`;
@@ -406,7 +411,7 @@ jobs:
               
               if (urls.length > 0) {
                 comment += '- **Deployed URLs**:\n';
-                urls.forEach(url => comment += `  - ${url}\n`);
+                urls.forEach(({ key, value }) => comment += `  - ${key}: ${value}\n`);
               }
               
               if ('${{ steps.final-status.outputs.permalink }}') {
@@ -461,9 +466,10 @@ jobs:
         run: |
           echo "Validating deployed application..."
           
-          URLS='${{ needs.deploy-with-error-handling.outputs.urls }}'
-          
-          if [ "$URLS" = "[]" ] || [ -z "$URLS" ]; then
+          URLS=$(echo '${{ needs.deploy-with-error-handling.outputs.deployment_outputs }}' \
+            | jq -r '.[].value | select(type == "string" and startswith("http"))')
+
+          if [ -z "$URLS" ]; then
             echo "No URLs to validate"
             echo "health_check_passed=true" >> $GITHUB_OUTPUT
             exit 0
@@ -471,7 +477,7 @@ jobs:
           
           ALL_HEALTHY=true
           
-          for url in $(echo "$URLS" | jq -r '.[]'); do
+          for url in $URLS; do
             echo "Checking health for: $url"
             
             # Try health endpoint first

--- a/examples/multi-environment.yml
+++ b/examples/multi-environment.yml
@@ -113,7 +113,7 @@ jobs:
     
     environment:
       name: staging
-      url: ${{ steps.deploy.outputs.urls && fromJson(steps.deploy.outputs.urls)[0] }}
+      url: ${{ steps.deploy.outputs.outputs && fromJson(steps.deploy.outputs.outputs)[0].value }}
     
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
@@ -121,7 +121,7 @@ jobs:
     
     outputs:
       deployment_success: ${{ steps.deploy.outputs.success }}
-      deployment_urls: ${{ steps.deploy.outputs.urls }}
+      deployment_outputs: ${{ steps.deploy.outputs.outputs }}
       app_name: ${{ steps.deploy.outputs.app }}
     
     steps:
@@ -167,7 +167,10 @@ jobs:
         with:
           script: |
             const success = '${{ steps.deploy.outputs.success }}' === 'true';
-            const urls = JSON.parse('${{ steps.deploy.outputs.urls || "[]" }}');
+            const deployed = JSON.parse('${{ steps.deploy.outputs.outputs || "[]" }}');
+            const urls = deployed
+              .map(o => o.value)
+              .filter(v => String(v).startsWith('http'));
             
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
@@ -202,13 +205,14 @@ jobs:
       - name: Run Integration Tests
         env:
           # Pass deployment URLs to integration tests
-          STAGING_URLS: ${{ needs.deploy-staging.outputs.deployment_urls }}
+          STAGING_OUTPUTS: ${{ needs.deploy-staging.outputs.deployment_outputs }}
           TEST_ENVIRONMENT: staging
         run: |
           echo "Running integration tests against staging environment..."
           
           # Extract first URL for testing
-          STAGING_URL=$(echo '${{ needs.deploy-staging.outputs.deployment_urls }}' | jq -r '.[0] // ""')
+          STAGING_URL=$(echo "$STAGING_OUTPUTS" \
+            | jq -r 'first(.[].value | select(type == "string" and startswith("http"))) // ""')
           
           if [ -n "$STAGING_URL" ]; then
             echo "Testing against: $STAGING_URL"
@@ -235,7 +239,7 @@ jobs:
       - name: Performance Tests
         continue-on-error: true
         env:
-          STAGING_URL: ${{ fromJson(needs.deploy-staging.outputs.deployment_urls)[0] }}
+          STAGING_URL: ${{ fromJson(needs.deploy-staging.outputs.deployment_outputs)[0].value }}
         run: |
           if [ -n "$STAGING_URL" ]; then
             echo "Running basic performance checks..."
@@ -261,7 +265,7 @@ jobs:
     # Production environment with protection rules
     environment:
       name: production
-      url: ${{ steps.deploy.outputs.urls && fromJson(steps.deploy.outputs.urls)[0] }}
+      url: ${{ steps.deploy.outputs.outputs && fromJson(steps.deploy.outputs.outputs)[0].value }}
     
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
@@ -269,7 +273,7 @@ jobs:
     
     outputs:
       deployment_success: ${{ steps.deploy.outputs.success }}
-      deployment_urls: ${{ steps.deploy.outputs.urls }}
+      deployment_outputs: ${{ steps.deploy.outputs.outputs }}
     
     steps:
       - name: Checkout
@@ -330,10 +334,11 @@ jobs:
           echo "- **Resources Changed**: ${{ steps.deploy.outputs.resource_changes }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Deployment Time**: $(date -u)" >> $GITHUB_STEP_SUMMARY
           
-          URLS='${{ steps.deploy.outputs.urls }}'
-          if [ "$URLS" != "[]" ] && [ -n "$URLS" ]; then
+          URLS=$(echo '${{ steps.deploy.outputs.outputs }}' \
+            | jq -r '.[].value | select(type == "string" and startswith("http"))')
+          if [ -n "$URLS" ]; then
             echo "- **Live URLs**:" >> $GITHUB_STEP_SUMMARY
-            echo "$URLS" | jq -r '.[] | "  - " + .' >> $GITHUB_STEP_SUMMARY
+            echo "$URLS" | sed 's/^/  - /' >> $GITHUB_STEP_SUMMARY
           fi
           
           if [ -n "${{ steps.deploy.outputs.permalink }}" ]; then
@@ -354,13 +359,13 @@ jobs:
       # Validate production deployment
       - name: Production Health Checks
         env:
-          PRODUCTION_URLS: ${{ needs.deploy-production.outputs.deployment_urls }}
+          PRODUCTION_OUTPUTS: ${{ needs.deploy-production.outputs.deployment_outputs }}
         run: |
           echo "Validating production deployment..."
           
-          URLS='${{ needs.deploy-production.outputs.deployment_urls }}'
-          
-          for url in $(echo "$URLS" | jq -r '.[]'); do
+          URLS=$(echo "$PRODUCTION_OUTPUTS" | jq -r '.[].value | select(type == "string" and startswith("http"))')
+
+          for url in $URLS; do
             echo "Validating: $url"
             
             # Health check with retry logic

--- a/examples/pr-workflow.yml
+++ b/examples/pr-workflow.yml
@@ -173,7 +173,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const urls = JSON.parse('${{ steps.deploy.outputs.urls }}');
+            // Every output the app declared, as {key, value} pairs.
+            const deployed = JSON.parse('${{ steps.deploy.outputs.outputs }}' || '[]');
+            const urls = deployed.filter(o => String(o.value).startsWith('http'));
             const stage = '${{ steps.deploy.outputs.stage }}';
             const app = '${{ steps.deploy.outputs.app }}';
             const changes = '${{ steps.deploy.outputs.resource_changes }}';
@@ -187,8 +189,8 @@ jobs:
             
             if (urls.length > 0) {
               comment += '\n**Deployed URLs**:\n';
-              urls.forEach(url => {
-                comment += `- ${url}\n`;
+              urls.forEach(({ key, value }) => {
+                comment += `- ${key}: ${value}\n`;
               });
             }
             


### PR DESCRIPTION
Two documentation-contract tickets from the #134 stream. No source change, so `dist/` is untouched and the bundle gate is not involved.

Closes #135, #138.

## Anyone following the docs got a workflow that fails

Two independent faults overlapped on the same lines:

- `@v1` has never been tagged. The only floating major on the remote is `v0`.
- `kodehort/sst-operations-action` is the local checkout directory, not the repository. 60 of the 86 refs used it — every one in `API.md` and `TROUBLESHOOTING.md` — so those examples were wrong on the name *and* the tag.

All 86 now pin `kodehort/sst-ops-action@v0`; the one "pin a specific version" example pins `@v0.7.42`. `CHANGELOG.md` is deliberately untouched — its entries pin the version each release shipped with, and rewriting them would falsify the record.

`package.json` and `bun.lock` carried the checkout-directory name too. Nothing reads it (`rollup.config.js` takes only `version`), but it is where the wrong name came from. `bun install --frozen-lockfile` still passes.

## The output contract disagreed with the action in both directions

**Emitted but undeclared.** Five outputs were written at runtime and declared nowhere: `error`, `planned_changes`, `resources`, `removed_resources`, `resources_removed`. `main.ts` iterates the formatter's keys blindly into `core.setOutput`, so they worked — they were invisible to anyone reading the contract. Declared, not removed, per the ticket.

**Declared but never emitted.** `API.md` carried a full reference section for a `urls` output, and the examples read `outputs.urls` in eleven places across four workflows. Nothing has emitted `urls` since `outputs` replaced it, so every one of those expressions expanded to an empty string and the health checks and PR comments built on them silently did nothing. They now read `outputs` and filter by value. `examples/error-handling.yml` was also reading `needs.deploy-with-error-handling.outputs.urls` from a job that declared no outputs at all.

Two descriptions were wrong rather than missing: `resource_changes` claimed "deploy/remove only" when `formatDiffOperation` sets it too, and `outputs` defined itself as "replaces urls".

## Guards

Both tickets are documentation, so both got a test that fails when the documentation drifts back.

`__tests__/docs/action-references.test.ts` reads the expected major from `package.json` rather than hardcoding `v0`, so it fails on `@v1` today and keeps holding after a major bump without anyone remembering.

`__tests__/outputs/action-metadata.test.ts` derives the emitted set by **running the formatter**, not from a hand-maintained list, so a new output key reaches the test the moment it can reach a consumer. It holds `action.yml`, the README table, the API reference and the example workflows to that set — the example check scoped to steps that actually `uses:` this action, since the examples read plenty of their own `run`-step outputs.

Every assertion is paired with a non-vacuity check, because a parse that quietly matches nothing looks identical to agreement. That earned its keep during development: the first README and API parsers returned zero rows, and the count assertion caught it rather than reporting a clean pass.

Both guards were verified red before green, and the example-workflow check was verified against the real fault by reintroducing `urls`.

## Scope note

The `urls` cleanup is not in #138's acceptance criteria. It is the same fault in the opposite direction, and fixing the metadata while leaving eleven broken example expressions seemed worse than either extreme. Easy to split out if you would rather.

517 → 523 tests. `bun run validate` clean, `fallow audit` verdict `pass`.

https://claude.ai/code/session_01QosYRj4tDN6NyPTbERLoZV
