### PR TITLE
test: stop a resolver test depending on the ambient Git ref

### DIFF
--- a/__tests__/inputs/resolve.test.ts
+++ b/__tests__/inputs/resolve.test.ts
@@ -76,13 +76,17 @@ describe("Resolving action inputs", () => {
     });
 
     it("prefers what the user set over the default", () => {
+      // Not "prod": createValidationContext reads GITHUB_REF, and on a run
+      // from main it reports isProduction, which makes a remove against a
+      // stage containing "prod" throw. This test is about defaults, so the
+      // stage name has no business deciding whether it passes.
       withInputs({
         "comment-mode": "always",
         "fail-on-error": "false",
         "max-output-size": "1000",
         operation: "remove",
         runner: "sst",
-        stage: "prod",
+        stage: "staging",
         token: "t",
       });
 


### PR DESCRIPTION
The release run for #150 failed on this test. `main` currently has no published release.

## What happened

`__tests__/inputs/resolve.test.ts` used `stage: "prod"` for a `remove` operation. `createValidationContext` reports `isProduction` when `GITHUB_REF === "refs/heads/main"`, and `validateOperationWithContext` then throws `Remove operation on production stage requires explicit confirmation` for a remove against a stage whose name contains "prod".

That ref is what a **release** run has. A pull request run has `refs/pull/N/merge`, and a laptop has no `GITHUB_REF` at all — so the test passed on PR CI and passed locally, and only failed once it reached `main`.

The test is about defaults being preferred over user-set values. The stage name has no business deciding whether it passes, so it is now `staging`, with the reason recorded next to it.

## Verified both ways

```
GITHUB_REF=refs/heads/main CI=true bun run test   # 536 passed — the release environment
bun run test                                       # 536 passed — the local one
```

The first of those is the check that was missing; it reproduces the failure on the previous commit and passes on this one.

Test-only change: `dist/` is untouched.

https://claude.ai/code/session_01QosYRj4tDN6NyPTbERLoZV
