### PR TITLE
docs: stop advertising the artifact upload (#153)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ this file records only things that cost a wasted run to discover.
   Nothing is lost; the working copy is untouched.
 - `jj commit` takes `--message`, not `-F`. Pass a file with
   `--message "$(cat <file>)"`.
-- `jj git push --bookmark <name>` needs no `--allow-new`; that flag does not exist.
+- `jj git push --bookmark <name>` pushes a new bookmark as-is. This jj version
+  rejects `--allow-new`; newer ones accept it, so check before assuming either.
 
 ## gh
 

--- a/API.md
+++ b/API.md
@@ -155,12 +155,10 @@ permissions:
   contents: read          # Read repository contents
   issues: write          # Create/update issue comments  
   pull-requests: write   # Create/update PR comments
-  actions: write         # Upload artifacts
 ```
 
 **Token Capabilities:**
 - Create and update PR/issue comments
-- Upload workflow artifacts
 - Set workflow status
 - Access repository metadata
 
@@ -1076,7 +1074,6 @@ Detailed behavior for each operation type.
 2. Parse deployment output for resources and generic outputs
 3. Extract URLs and other outputs from generic parsing
 4. Create PR comments with deployment results
-5. Upload artifacts with deployment logs
 
 **Typical Duration:** 30 seconds to 15 minutes (default timeout)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ bun run prepare
 1. Input parsing and validation via operation-specific parsers
 2. SST command execution through CLI utilities
 3. Output parsing and formatting
-4. GitHub integration for PR comments and artifact uploads
+4. GitHub integration for PR comments and workflow summaries
 5. Result reporting via GitHub Action outputs
 
 ### Input Validation and Error Handling

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Features:
 - Deploys all stack resources and extracts deployment outputs
 - Tracks resource changes (created, updated, unchanged)
 - Posts PR comments with deployment status
-- Generates workflow summaries and uploads artifacts
+- Generates workflow summaries
 
 ### Diff
 

--- a/examples/basic-deploy.yml
+++ b/examples/basic-deploy.yml
@@ -30,7 +30,6 @@ on:
 permissions:
   contents: read           # Read repository contents
   pull-requests: write    # Create/update PR comments (if applicable)
-  actions: write          # Upload workflow artifacts
 
 # Environment variables required for SST deployment
 env:

--- a/examples/cleanup.yml
+++ b/examples/cleanup.yml
@@ -57,7 +57,6 @@ on:
 # Required permissions for cleanup operations
 permissions:
   contents: read           # Read repository contents
-  actions: write          # Access workflow artifacts
   issues: write           # Comment on issues (for notifications)
   pull-requests: write    # Comment on PRs
 

--- a/examples/multi-environment.yml
+++ b/examples/multi-environment.yml
@@ -38,7 +38,6 @@ on:
 permissions:
   contents: read           # Read repository contents
   pull-requests: write    # Create/update PR comments
-  actions: write          # Upload workflow artifacts
   deployments: write      # Create deployment status
 
 # Global environment variables

--- a/examples/pr-workflow.yml
+++ b/examples/pr-workflow.yml
@@ -29,7 +29,6 @@ permissions:
   contents: read           # Read repository contents
   pull-requests: write    # Create/update PR comments
   issues: write           # Comment on issues
-  actions: write          # Upload workflow artifacts
 
 # Environment variables for SST deployment
 env:


### PR DESCRIPTION
Follow-up to #171.

#153 deleted `uploadArtifacts` and dropped `@actions/artifact`, but the documentation still described artifact upload as a feature of this action.

The part that actually matters: four example workflows told users to grant

```yaml
actions: write         # Upload workflow artifacts
```

The action can no longer use that permission, so every copy-paste of these examples over-privileges a workflow token for nothing. Removed from `basic-deploy`, `multi-environment`, `pr-workflow` and `cleanup`.

Also removed:
- `README.md` — "Generates workflow summaries and uploads artifacts"
- `API.md` — the `actions: write` permission block, "Upload workflow artifacts" from token capabilities, and step 5 "Upload artifacts with deployment logs" from the deploy process
- `CLAUDE.md` — "GitHub integration for PR comments and artifact uploads"

Nothing caught this automatically: `action-metadata.test.ts` and `action-references.test.ts` guard the *output* contract and version references, not feature prose.

Plus a wording fix in `AGENTS.md`: `jj git push --allow-new` is absent from this jj version rather than nonexistent, so a future agent on a newer jj should not distrust the note.

```
rg -in artifact README.md API.md CLAUDE.md action.yml examples/*.yml   # now empty
```

- [x] 490 tests pass, `bun run validate` clean
- [x] `bun fallow audit` passes